### PR TITLE
[BUG] Remove h-10 class from header to fix height

### DIFF
--- a/components/Nav.vue
+++ b/components/Nav.vue
@@ -39,7 +39,7 @@
         </button>
       </div>
     </nav>
-    <div class="w-full h-10 lg:block hidden" style="background-color: #330a0b">
+    <div class="w-full lg:block hidden" style="background-color: #330a0b">
       <div class="container flex w-full">
         <ul class="items-center hidden tracking-wide text-gray-300 uppercase lg:flex gap-x-10">
           <li>


### PR DESCRIPTION
Fix 2nd header height that is broken. From this

![image](https://github.com/ao-org/ao20-web/assets/6114492/7c8e64e9-055b-4be5-b74e-6375d81a824d)


To this

![image](https://github.com/ao-org/ao20-web/assets/6114492/b52ddc7b-b239-4137-a2ee-34923167f65a)
